### PR TITLE
micah/4039/hide edges on zoom

### DIFF
--- a/docs/network/interaction.html
+++ b/docs/network/interaction.html
@@ -57,6 +57,7 @@ var options = {
     dragNodes:true,
     dragView: true,
     hideEdgesOnDrag: false,
+    hideEdgesOnZoom: false,
     hideNodesOnDrag: false,
     hover: false,
     hoverConnectedEdges: true,
@@ -95,6 +96,7 @@ network.setOptions(options);
         <tr><td>dragNodes</td>              <td>Boolean</td>            <td><code>true</code></td>      <td>When true, the nodes that are not fixed can be dragged by the user.</td></tr>
         <tr><td>dragView</td>               <td>Boolean</td>            <td><code>true</code></td>      <td>When true, the view can be dragged around by the user.</td></tr>
         <tr><td>hideEdgesOnDrag</td>        <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the edges are not drawn when dragging the view. This can greatly speed up responsiveness on dragging, improving user experience.</td></tr>
+        <tr><td>hideEdgesOnZoom</td>        <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the edges are not drawn when zooming the view. This can greatly speed up responsiveness on zooming, improving user experience.</td></tr>        
         <tr><td>hideNodesOnDrag</td>        <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the nodes are not drawn when dragging the view. This can greatly speed up responsiveness on dragging, improving user experience.</td></tr>
         <tr><td>hover</td>                  <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the nodes use their hover colors when the mouse moves over them.</td></tr>
         <tr><td>hoverConnectedEdges</td>     <td>Boolean</td>            <td><code>true</code></td>      <td>When true, on hovering over a node, it's connecting edges are highlighted.</td></tr>

--- a/examples/network/exampleApplications/neighbourhoodHighlight.html
+++ b/examples/network/exampleApplications/neighbourhoodHighlight.html
@@ -68,7 +68,8 @@
       physics: false,
       interaction: {
         tooltipDelay: 200,
-        hideEdgesOnDrag: true
+        hideEdgesOnDrag: true,
+        hideEdgesOnZoom: true,
       }
     };
     var data = {nodes:nodesDataset, edges:edgesDataset} // Note: data is coming from ./datasources/WorldCup2014.js

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -64,9 +64,11 @@ class CanvasRenderer {
     this.allowRedraw = true;
 
     this.dragging = false;
+    this.zooming = false;
     this.options = {};
     this.defaultOptions = {
       hideEdgesOnDrag: false,
+      hideEdgesOnZoom: false,
       hideNodesOnDrag: false
     };
     util.extend(this.options, this.defaultOptions);
@@ -81,6 +83,14 @@ class CanvasRenderer {
   bindEventListeners() {
     this.body.emitter.on("dragStart", () => { this.dragging = true; });
     this.body.emitter.on("dragEnd", () => { this.dragging = false; });
+    this.body.emitter.on("zoom", () => {
+      this.zooming = true;
+      window.clearTimeout(this.zoomTimeoutId)
+      this.zoomTimeoutId = window.setTimeout(() => { 
+        this.zooming = false;
+        this._requestRedraw.bind(this)()
+      }, 250) 
+    });
     this.body.emitter.on("_resizeNodes", () => { this._resizeNodes(); });
     this.body.emitter.on("_redraw", () => {
       if (this.renderingActive === false) {
@@ -264,7 +274,10 @@ class CanvasRenderer {
       ctx.closePath();
 
       if (hidden === false) {
-        if (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) {
+        if (
+          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) && 
+          (this.zooming === false || (this.zooming === true && this.options.hideEdgesOnZoom === false))
+        ) {
           this._drawEdges(ctx);
         }
       }

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -78,7 +78,7 @@ class InteractionHandler {
   setOptions(options) {
     if (options !== undefined) {
       // extend all but the values in fields
-      let fields = ['hideEdgesOnDrag','hideNodesOnDrag','keyboard','multiselect','selectable','selectConnectedEdges'];
+      let fields = ['hideEdgesOnDrag','hideEdgesOnZoom','hideNodesOnDrag','keyboard','multiselect','selectable','selectConnectedEdges'];
       util.selectiveNotDeepExtend(fields, this.options, options);
 
       // merge the keyboard options in.

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -152,6 +152,7 @@ let allOptions = {
     dragNodes: { boolean: bool },
     dragView: { boolean: bool },
     hideEdgesOnDrag: { boolean: bool },
+    hideEdgesOnZoom: { boolean: bool },
     hideNodesOnDrag: { boolean: bool },
     hover: { boolean: bool },
     keyboard: {
@@ -560,6 +561,7 @@ let configureOptions = {
     dragNodes: true,
     dragView: true,
     hideEdgesOnDrag: false,
+    hideEdgesOnZoom: false,    
     hideNodesOnDrag: false,
     hover: false,
     keyboard: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visjs-network",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "description": "A dynamic, browser-based network visualization library.",
   "homepage": "http://visjs.org/",
   "license": "(Apache-2.0 OR MIT)",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "async": "^2.5.0",
-    "babel-core": "^6.25.0",
+    "babel-core": "^6.26.3",
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visjs-network",
-  "version": "4.21.1",
+  "version": "4.21.2",
   "description": "A dynamic, browser-based network visualization library.",
   "homepage": "http://visjs.org/",
   "license": "(Apache-2.0 OR MIT)",


### PR DESCRIPTION
This PR adds a new network interaction option to hide edges on zoom, `hideEdgesOnZoom`

This new option is patterned after the existing `hideEdgesOnDrag` option.

fix #4039 

## 📄 steps to test
- `cd vis`
- run a local server on port `8080`
- visit the **Dynamic Data - Neighbourhood Highlight** example at  http://localhost:8080/examples/network/exampleApplications/neighbourhoodHighlight.html
- scroll to zoom
- notice that edges are not shown during zooming, and are shown again when zooming ends ✨  

![hide-edges-on-zoom-1](https://user-images.githubusercontent.com/2119400/43025275-ed0c7e28-8c25-11e8-8ad2-1b96f31cd395.gif)

---

ported over from https://github.com/almende/vis/pull/4042