### PR TITLE
remove use-strict from header.js

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -22,5 +22,3 @@
  *
  * Vis.js may be distributed under either license.
  */
-
-'use strict'


### PR DESCRIPTION
This PR fixes a bug related to the `use-strict` annotation

fix #16