### PR TITLE
micah/22/edge arrow support dot file

### DIFF
--- a/examples/network/data/dotLanguage/dotEdgeStyles.html
+++ b/examples/network/data/dotLanguage/dotEdgeStyles.html
@@ -164,22 +164,27 @@
     ' lines[label="LINES"]; \n' +
     ' ahs[label="ARROW HEADS"]; \n' +
     '\n' +
+    ' // Child nodes\n' +
+    ' dot[label="both dot"]; \n' +
+    ' vee[label="back vee"]; \n' +
+    ' diamond[label="diamond and box"]; \n' +
+    '\n' +
     ' // Line styles\n' +
     ' lines -- solid[label="solid pink", color="pink"]; \n' +
     ' lines -- dashed[label="dashed green", style="dashed", color="green"]; \n' +
     ' lines -- dotted[label="dotted purple", style="dotted", color="purple"]; \n' +
     '\n' +
     ' // Arrowhead styles\n' +
-    ' ahs -> dot[label="dot", arrowhead=dot]; \n' +
     ' ahs -> box[label="box", arrowhead=box]; \n' +
     ' ahs -> crow[label="crow", arrowhead=crow]; \n' +
     ' ahs -> curve[label="curve", arrowhead=curve]; \n' +
     ' ahs -> icurve[label="icurve", arrowhead=icurve]; \n' +
     ' ahs -> normal[label="normal", arrowhead=normal]; \n' +
     ' ahs -> inv[label="inv", arrowhead=inv]; \n' +
-    ' ahs -> diamond[label="diamond", arrowhead=diamond]; \n' +
+    ' ahs -> diamond[label="diamond and box", dir=both, arrowhead=diamond, arrowtail=box]; \n' +
+    ' ahs -> dot[label="both dot", dir=both, arrowhead=dot, arrowtail=dot]; \n' +
     ' ahs -> tee[label="tee", arrowhead=tee]; \n' +
-    ' ahs -> vee[label="vee", arrowhead=vee]; \n' +
+    ' ahs -> vee[label="back vee", dir=back, arrowtail=vee]; \n' +
     '}';
 
   // create a network

--- a/examples/network/data/dotLanguage/dotEdgeStyles.html
+++ b/examples/network/data/dotLanguage/dotEdgeStyles.html
@@ -98,21 +98,43 @@
 
     <table border=1>
       <tr>
-        <th>Attributes</th><th>Desriptions</th>
+        <th>Attributes</th><th>Description</th><th>Possible Values</th><th>Default Value</th>
       </tr>
       <tr>
-        <td align="center">label</td><td>Text displayed on the edge</td>
+        <td align="center">label</td>
+        <td>Text displayed on the edge</td>
+        <td></td>
+        <td></td>
       </tr>
       <tr>
-        <td align="center">color</td><td>Edge color</td>
+        <td align="center">color</td>
+        <td>Edge color</td>
+        <td></td>
+        <td></td>
       </tr>
       <tr>
         <td align="center">style</td>
-        <td>Edge style (solid, dashed, dotted)</td>
+        <td>Edge style</td>
+        <td>"solid", "dashed", "dotted"</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="center">dir</td>
+        <td>Arrow direction</td>
+        <td>"forward", "both", "back", "none"</td>
+        <td>"forward"</td>
       </tr>
       <tr>
         <td align="center">arrowhead</td>
-        <td>Arrow style (dot, box, crow, curve, icurve, normal, inv, diamond, tee, vee)</td>
+        <td>Arrow tail style</td>
+        <td>"dot", "box", "crow", "curve", "icurve", "normal", "inv", "diamond", "tee", "vee"</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="center">arrowtail</td>
+        <td>Arrow head style</td>
+        <td>"dot", "box", "crow", "curve", "icurve", "normal", "inv", "diamond", "tee", "vee"</td>
+        <td></td>
       </tr>
     </table>
   </div>

--- a/lib/network/dotparser.js
+++ b/lib/network/dotparser.js
@@ -684,6 +684,7 @@ function parseEdge(graph, from) {
  * @return {Object | null} attr
  */
 function parseAttributeList() {
+  var i
   var attr = null
 
   // edge styles of dot and vis
@@ -693,6 +694,33 @@ function parseAttributeList() {
     dotted: [1, 5]
   }
 
+  /**
+   * Define arrow types.
+   * vis currently supports types defined in 'arrowTypes'.
+   * Details of arrow shapes are described in
+   * http://www.graphviz.org/content/arrow-shapes
+   */
+  var arrowTypes = {
+    dot: 'circle',
+    box: 'box',
+    crow: 'crow',
+    curve: 'curve',
+    icurve: 'inv_curve',
+    normal: 'triangle',
+    inv: 'inv_triangle',
+    diamond: 'diamond',
+    tee: 'bar',
+    vee: 'vee'
+  }
+  /**
+   * 'attr_list' contains attributes for checking if some of them are affected
+   * later. For instance, both of 'arrowhead' and 'dir' (edge style defined
+   * in DOT) make changes to 'arrows' attribute in vis.
+   */
+  var attr_list = new Array()
+  var attr_names = new Array() // used for checking the case.
+
+  // parse attributes
   while (token === '[') {
     getToken()
     attr = {}
@@ -718,30 +746,20 @@ function parseAttributeList() {
         value = edgeStyles[value]
       }
 
-      // Define arrow types.
-      // vis.js currently supports types defined in 'arrowTypes'.
-      // Details of arrow shapes are described in
-      // http://www.graphviz.org/content/arrow-shapes
-      var arrowTypes = {
-        dot: 'circle',
-        box: 'box',
-        crow: 'crow',
-        curve: 'curve',
-        icurve: 'inv_curve',
-        normal: 'triangle',
-        inv: 'inv_triangle',
-        diamond: 'diamond',
-        tee: 'bar',
-        vee: 'vee'
-      }
-
+      var arrowType
       if (name === 'arrowhead') {
-        var arrowType = arrowTypes[value]
+        arrowType = arrowTypes[value]
         name = 'arrows'
         value = { to: { enabled: true, type: arrowType } }
       }
 
-      setValue(attr, name, value) // name can be a path
+      if (name === 'arrowtail') {
+        arrowType = arrowTypes[value]
+        name = 'arrows'
+        value = { from: { enabled: true, type: arrowType } }
+      }
+      attr_list.push({ attr: attr, name: name, value: value })
+      attr_names.push(name)
 
       getToken()
       if (token == ',') {
@@ -753,6 +771,232 @@ function parseAttributeList() {
       throw newSyntaxError('Bracket ] expected')
     }
     getToken()
+  }
+
+  /**
+   * As explained in [1], graphviz has limitations for combining
+   * arrow[head|tail] and dir. If the attribute list includes 'dir',
+   * only following cases are supported:
+   *   1. both or none + arrowhead, arrowtail
+   *   2. forward + arrowhead (arrowtail is not affedted)
+   *   3. back + arrowtail (arrowhead is not affected)
+   * [1] https://www.graphviz.org/doc/info/attrs.html#h:undir_note
+   */
+  if (attr_names.includes('dir')) {
+    var idx = {} // get index of 'arrows' and 'dir'
+    idx.arrows = {}
+    for (i = 0; i < attr_list.length; i++) {
+      if (attr_list[i].name === 'arrows') {
+        if (attr_list[i].value.to != null) {
+          idx.arrows.to = i
+        } else if (attr_list[i].value.from != null) {
+          idx.arrows.from = i
+        } else {
+          throw newSyntaxError('Invalid value of arrows')
+        }
+      } else if (attr_list[i].name === 'dir') {
+        idx.dir = i
+      }
+    }
+    // first, add default arrow shape if it is not assigned to avoid error
+    var dir_type = attr_list[idx.dir].value
+    if (!attr_names.includes('arrows')) {
+      if (dir_type === 'both') {
+        attr_list.push({
+          attr: attr_list[idx.dir].attr,
+          name: 'arrows',
+          value: { to: { enabled: true } }
+        })
+        idx.arrows.to = attr_list.length - 1
+        attr_list.push({
+          attr: attr_list[idx.dir].attr,
+          name: 'arrows',
+          value: { from: { enabled: true } }
+        })
+        idx.arrows.from = attr_list.length - 1
+      } else if (dir_type === 'forward') {
+        attr_list.push({
+          attr: attr_list[idx.dir].attr,
+          name: 'arrows',
+          value: { to: { enabled: true } }
+        })
+        idx.arrows.to = attr_list.length - 1
+      } else if (dir_type === 'back') {
+        attr_list.push({
+          attr: attr_list[idx.dir].attr,
+          name: 'arrows',
+          value: { from: { enabled: true } }
+        })
+        idx.arrows.from = attr_list.length - 1
+      } else if (dir_type === 'none') {
+        attr_list.push({
+          attr: attr_list[idx.dir].attr,
+          name: 'arrows',
+          value: ''
+        })
+        idx.arrows.to = attr_list.length - 1
+      } else {
+        throw newSyntaxError('Invalid dir type "' + dir_type + '"')
+      }
+    }
+    var from_type
+    var to_type
+    // update 'arrows' attribute from 'dir'.
+    if (dir_type === 'both') {
+      // both of shapes of 'from' and 'to' are given
+      if (idx.arrows.to && idx.arrows.from) {
+        to_type = attr_list[idx.arrows.to].value.to.type
+        from_type = attr_list[idx.arrows.from].value.from.type
+        attr_list[idx.arrows.to] = {
+          attr: attr_list[idx.arrows.to].attr,
+          name: attr_list[idx.arrows.to].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+        attr_list.splice(idx.arrows.from, 1)
+        // shape of 'to' is assigned and use default to 'from'
+      } else if (idx.arrows.to) {
+        to_type = attr_list[idx.arrows.to].value.to.type
+        from_type = 'arrow'
+        attr_list[idx.arrows.to] = {
+          attr: attr_list[idx.arrows.to].attr,
+          name: attr_list[idx.arrows.to].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+        // only shape of 'from' is assigned and use default for 'to'
+      } else if (idx.arrows.from) {
+        to_type = 'arrow'
+        from_type = attr_list[idx.arrows.from].value.from.type
+        attr_list[idx.arrows.from] = {
+          attr: attr_list[idx.arrows.from].attr,
+          name: attr_list[idx.arrows.from].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+      }
+    } else if (dir_type === 'back') {
+      // given both of shapes, but use only 'from'
+      if (idx.arrows.to && idx.arrows.from) {
+        to_type = ''
+        from_type = attr_list[idx.arrows.from].value.from.type
+        attr_list[idx.arrows.from] = {
+          attr: attr_list[idx.arrows.from].attr,
+          name: attr_list[idx.arrows.from].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+        // given shape of 'to', but does not use it
+      } else if (idx.arrows.to) {
+        to_type = ''
+        from_type = 'arrow'
+        idx.arrows.from = idx.arrows.to
+        attr_list[idx.arrows.from] = {
+          attr: attr_list[idx.arrows.from].attr,
+          name: attr_list[idx.arrows.from].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+        // assign given 'from' shape
+      } else if (idx.arrows.from) {
+        to_type = ''
+        from_type = attr_list[idx.arrows.from].value.from.type
+        attr_list[idx.arrows.to] = {
+          attr: attr_list[idx.arrows.from].attr,
+          name: attr_list[idx.arrows.from].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+      }
+      attr_list[idx.arrows.from] = {
+        attr: attr_list[idx.arrows.from].attr,
+        name: attr_list[idx.arrows.from].name,
+        value: {
+          from: {
+            enabled: true,
+            type: attr_list[idx.arrows.from].value.from.type
+          }
+        }
+      }
+    } else if (dir_type === 'none') {
+      var idx_arrow
+      if (idx.arrows.to) {
+        idx_arrow = idx.arrows.to
+      } else {
+        idx_arrow = idx.arrows.from
+      }
+      attr_list[idx_arrow] = {
+        attr: attr_list[idx_arrow].attr,
+        name: attr_list[idx_arrow].name,
+        value: ''
+      }
+    } else if (dir_type === 'forward') {
+      // given both of shapes, but use only 'to'
+      if (idx.arrows.to && idx.arrows.from) {
+        to_type = attr_list[idx.arrows.to].value.to.type
+        from_type = ''
+        attr_list[idx.arrows.to] = {
+          attr: attr_list[idx.arrows.to].attr,
+          name: attr_list[idx.arrows.to].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+        // assign given 'to' shape
+      } else if (idx.arrows.to) {
+        to_type = attr_list[idx.arrows.to].value.to.type
+        from_type = ''
+        attr_list[idx.arrows.to] = {
+          attr: attr_list[idx.arrows.to].attr,
+          name: attr_list[idx.arrows.to].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+        // given shape of 'from', but does not use it
+      } else if (idx.arrows.from) {
+        to_type = 'arrow'
+        from_type = ''
+        idx.arrows.to = idx.arrows.from
+        attr_list[idx.arrows.to] = {
+          attr: attr_list[idx.arrows.to].attr,
+          name: attr_list[idx.arrows.to].name,
+          value: {
+            to: { enabled: true, type: to_type },
+            from: { enabled: true, type: from_type }
+          }
+        }
+      }
+      attr_list[idx.arrows.to] = {
+        attr: attr_list[idx.arrows.to].attr,
+        name: attr_list[idx.arrows.to].name,
+        value: {
+          to: { enabled: true, type: attr_list[idx.arrows.to].value.to.type }
+        }
+      }
+    } else {
+      throw newSyntaxError('Invalid dir type "' + dir_type + '"')
+    }
+    // remove 'dir' attribute no need anymore
+    attr_list.splice(idx.dir, 1)
+  }
+  var nof_attr_list = attr_list.length
+  for (i = 0; i < nof_attr_list; i++) {
+    setValue(attr_list[i].attr, attr_list[i].name, attr_list[i].value)
   }
 
   return attr
@@ -926,8 +1170,6 @@ function DOTToGraph(data) {
           id: dotEdge.from
         }
       }
-
-      // TODO: support for attributes 'dir' (edge arrows)
 
       if (dotEdge.to instanceof Object) {
         to = dotEdge.to.nodes


### PR DESCRIPTION
This PR accepts the nice contribution by @geminoa in PR https://github.com/almende/vis/pull/3888

---

notice the differences:

dot --> both dot
vee --> back vee

http://localhost:8080/examples/network/data/dotLanguage/dotEdgeStyles.html

## before 
![before-screen shot 2018-09-03 at 2 17 10 pm](https://user-images.githubusercontent.com/2119400/45002071-cb3cb800-af87-11e8-9209-1bc827689ef2.png)


## after
![after-screen shot 2018-09-03 at 2 42 21 pm](https://user-images.githubusercontent.com/2119400/45002074-ce37a880-af87-11e8-8650-52705599bc59.png)
