### PR TITLE
Fix detecting node hover after hovering an edge

### DIFF
--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -647,7 +647,17 @@ class SelectionHandler {
     }
 
     if (object !== undefined) {
-      hoverChanged = hoverChanged || this.emitHoverEvent(event, pointer, object)
+      const hoveredEdgesCount = Object.keys(this.hoverObj.edges).length
+      const hoveredNodesCount = Object.keys(this.hoverObj.nodes).length
+      const newOnlyHoveredEdge =
+        object instanceof Edge &&
+        hoveredEdgesCount === 0 &&
+        hoveredNodesCount === 0
+
+      if (hoverChanged || newOnlyHoveredEdge) {
+        hoverChanged = this.emitHoverEvent(event, pointer, object)
+      }
+
       if (object instanceof Node && this.options.hoverConnectedEdges === true) {
         this._hoverConnectedEdges(object)
       }


### PR DESCRIPTION
This PR fixes node hover when mouse moves from an edge.

This PR ports over the fix from @Gelio from ancestor repo PR almende/vis#4027

fix #28 
