### PR TITLE
Correct type of zoomSpeed in 'lib/network/opitons.js'

### DIFF
--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -664,7 +664,7 @@ let configureOptions = {
     hoverConnectedEdges: true,
     tooltipDelay: [300, 0, 1000, 25],
     zoomView: true,
-    zoomSpeed: 1
+    zoomSpeed: [1, 1, 1, 1]
   },
   manipulation: {
     enabled: false,


### PR DESCRIPTION
`zoomSpeed` is introduced for configurable manual zoom speed and the
type of value is `number` as described in [1].

However, it should be an array of `number` if it is used with
Configurator class, or an error is occured in _handleObject().
This update is to correct the type of zoomSpeed and fix #37.

[1] https://github.com/almende/vis/pull/3657